### PR TITLE
Add Cyclone DDS as default supported DDS scheme

### DIFF
--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -79,9 +79,8 @@ jobs:
           file: ./${{ inputs.dockerfile }}
           platforms: ${{ inputs.architectures }}
           push: true
-          no-cache: true
-          # cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
-          # cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
+          cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
+          cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -46,6 +46,9 @@ jobs:
           username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
           password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
 
+      - name: Pull base image
+        run: docker pull ${{ inputs.base_image }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -73,7 +76,7 @@ jobs:
           file: ./${{ inputs.dockerfile }}
           platforms: ${{ inputs.architectures }}
           push: true
-          no-cache:      true
+          no-cache: true
           # cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
           # cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -73,7 +73,7 @@ jobs:
           file: ./${{ inputs.dockerfile }}
           platforms: ${{ inputs.architectures }}
           push: true
-          cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
+          # cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
           cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -49,9 +49,6 @@ jobs:
       - name: Pull base image
         run: docker pull ${{ inputs.base_image }}
 
-      - name: Debug - Echo Date
-        run: date
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -73,8 +73,9 @@ jobs:
           file: ./${{ inputs.dockerfile }}
           platforms: ${{ inputs.architectures }}
           push: true
+          no-cache:      true
           # cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }}
-          cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
+          # cache-to:   type=registry,ref=lcas.lincoln.ac.uk/cache/${{ inputs.push_image }}:${{ inputs.ros_distro }},mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -49,6 +49,9 @@ jobs:
       - name: Pull base image
         run: docker pull ${{ inputs.base_image }}
 
+      - name: Debug - Echo Date
+        run: date
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -35,7 +35,7 @@ jobs:
   ros-cuda-humble:
     uses: ./.github/workflows/_build-image.yaml
     with:
-      base_image:    nvidia/cuda:11.8.0-runtime-ubuntu22.04
+      base_image:    nvidia/cuda:11.8.0-devel-ubuntu22.04
       push_image:    ros_cuda
       ros_distro:    humble
       dockerfile:    cuda.dockerfile
@@ -45,7 +45,7 @@ jobs:
   ros-cuda-jazzy:
     uses: ./.github/workflows/_build-image.yaml
     with:
-      base_image:    nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
+      base_image:    nvidia/cuda:12.9.1-devel-ubuntu24.04
       push_image:    ros_cuda
       ros_distro:    jazzy
       dockerfile:    cuda.dockerfile

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -37,7 +37,7 @@ jobs:
     with:
       base_image:    nvidia/cuda:11.8.0-runtime-ubuntu22.04
       push_image:    ros_cuda
-      ros_distro:      humble
+      ros_distro:    humble
       dockerfile:    cuda.dockerfile
       architectures: linux/amd64
     secrets: inherit

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -35,7 +35,7 @@ jobs:
   ros-cuda-humble:
     uses: ./.github/workflows/_build-image.yaml
     with:
-      base_image:    nvidia/cuda:11.8.0-devel-ubuntu22.04
+      base_image:    nvidia/cuda:11.8.0-runtime-ubuntu22.04
       push_image:    ros_cuda
       ros_distro:    humble
       dockerfile:    cuda.dockerfile
@@ -45,7 +45,7 @@ jobs:
   ros-cuda-jazzy:
     uses: ./.github/workflows/_build-image.yaml
     with:
-      base_image:    nvidia/cuda:12.9.1-devel-ubuntu24.04
+      base_image:    nvidia/cuda:12.9.1-runtime-ubuntu24.04
       push_image:    ros_cuda
       ros_distro:    jazzy
       dockerfile:    cuda.dockerfile

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -13,8 +13,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update || true \
     && apt-get install -y --no-install-recommends gnupg ca-certificates \
     && apt-get update \
-    && apt-get upgrade -y \
-    apt-get install -y --no-install-recommends \
+    && apt-get upgrade -y
+
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     cmake \
@@ -26,10 +27,9 @@ RUN apt-get update || true \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions && \
     rm -rf /var/lib/apt/lists/* \
-    && locale-gen en_GB.UTF-8 \
-    && update-locale LC_ALL=en_GB.UTF-8 LANG=en_GB.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
+ENV LANG=en_GB.UTF-8
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions && \
-    rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.UTF-8
 
@@ -46,7 +45,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && rm -rf /var/lib/apt/lists/*
 
 # Cyclone DDS Config
-COPY cyclonedds.xml /etc/cyclonedds.xml 
+COPY cyclonedds.xml /etc/cyclonedds.xml
 
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -10,7 +10,8 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* &&\
+    apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \
     ca-certificates \
     cmake \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -47,6 +47,7 @@ COPY cyclonedds.xml /etc/cyclonedds.xml
   
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \
+    echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /home/${USERNAME}/.bashrc && \
     echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
     echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
     echo "alias t='tmux'" >> /etc/bash.bashrc && \
@@ -54,6 +55,6 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
     echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
     echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
 
-USER ros
+USER ${USERNAME}
 CMD ["bash", "-l"]
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -38,7 +38,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME \
   && rm -rf /var/lib/apt/lists/*
 
-COPY docker/cyclonedds.xml /etc/cyclonedds.xml 
+COPY cyclonedds.xml /etc/cyclonedds.xml 
   
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -10,10 +10,8 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get clean && rm -rf /var/cache/apt/archives/* &&\
-    apt-get update && apt-get upgrade -y
-
-RUN apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
     build-essential \
     ca-certificates \
     cmake \
@@ -23,8 +21,9 @@ RUN apt-get install -y \
     unzip \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-    python3-colcon-common-extensions \
-    && rm -rf /var/lib/apt/lists/*
+    python3-colcon-common-extensions && \
+    rm -rf /var/lib/apt/lists/*  && \
+    apt-get clean && rm -rf /var/cache/apt/archives/*
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -34,10 +34,9 @@ ARG USERNAME=ros
 ARG USER_UID=1001
 ARG USER_GID=$USER_UID
 
-# Create a non-root user
+# Create a non-root user and add sudo support for the non-root user
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # Add sudo support for the non-root user
     && apt-get update \
     && apt-get install -y --no-install-recommends sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
@@ -53,7 +52,8 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
     echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
     echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
     echo "alias t='tmux'" >> /etc/bash.bashrc && \
-    echo "alias cls='clear'" >> /etc/bash.bashrc
+    echo "alias cls='clear'" >> /etc/bash.bashrc && \
+    chown ${USERNAME}:${USER_GID} /home/${USERNAME}/.bashrc
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV CYCLONEDDS_URI=file:///etc/cyclonedds.xml

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -12,16 +12,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \
+    ca-certificates \
     cmake \
     git \
     curl \
     wget \
     unzip \
     ros-${ROS_DISTRO}-ros-base \
-    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
-
+    
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 
 ARG USERNAME=ros
@@ -38,6 +38,10 @@ RUN groupadd --gid $USER_GID $USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME \
   && rm -rf /var/lib/apt/lists/*
 
+# Cyclone DDS
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
 COPY cyclonedds.xml /etc/cyclonedds.xml 
   
 # Configure bash profile
@@ -49,5 +53,6 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
     echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
     echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
 
+USER ros
 CMD ["bash", "-l"]
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -22,8 +22,7 @@ RUN apt-get update && apt-get upgrade -y && \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions && \
-    rm -rf /var/lib/apt/lists/*  && \
-    apt-get clean && rm -rf /var/cache/apt/archives/*
+    rm -rf /var/lib/apt/lists/*
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -38,7 +38,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME \
   && rm -rf /var/lib/apt/lists/*
 
-COPY ./docker/cyclonedds.xml /etc/cyclonedds.xml 
+COPY docker/cyclonedds.xml /etc/cyclonedds.xml 
   
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     wget \
     unzip \
     ros-${ROS_DISTRO}-ros-base \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,12 +38,16 @@ RUN groupadd --gid $USER_GID $USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME \
   && rm -rf /var/lib/apt/lists/*
 
+COPY ./docker/cyclonedds.xml /etc/cyclonedds.xml 
+  
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \
     echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
     echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
     echo "alias t='tmux'" >> /etc/bash.bashrc && \
-    echo "alias cls='clear'" >> /etc/bash.bashrc
+    echo "alias cls='clear'" >> /etc/bash.bashrc && \
+    echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
+    echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
 
 CMD ["bash", "-l"]
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -10,8 +10,11 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y \
+RUN apt-get update || true \
+    && apt-get install -y --no-install-recommends gnupg ca-certificates \
+    && apt-get update \
+    && apt-get upgrade -y \
+    apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     cmake \
@@ -22,7 +25,11 @@ RUN apt-get update && apt-get upgrade -y && \
     ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
+    && locale-gen en_GB.UTF-8 \
+    && update-locale LC_ALL=en_GB.UTF-8 LANG=en_GB.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/apt/lists/*
 
-ENV LANG=en_GB.UTF-8
+ENV LANG=en_US.UTF-8
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -10,14 +10,12 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update || true \
-    && apt-get install -y --no-install-recommends gnupg ca-certificates \
-    && apt-get update \
-    && apt-get upgrade -y
-
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    gnupg \
     cmake \
     git \
     curl \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -53,9 +53,10 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
     echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
     echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
     echo "alias t='tmux'" >> /etc/bash.bashrc && \
-    echo "alias cls='clear'" >> /etc/bash.bashrc && \
-    echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
-    echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
+    echo "alias cls='clear'" >> /etc/bash.bashrc
+
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ENV CYCLONEDDS_URI=file:///etc/cyclonedds.xml
 
 USER ${USERNAME}
 CMD ["bash", "-l"]

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -11,7 +11,9 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get clean && rm -rf /var/cache/apt/archives/* &&\
-    apt-get update && apt-get upgrade -y && apt-get install -y \
+    apt-get update && apt-get upgrade -y
+
+RUN apt-get install -y \
     build-essential \
     ca-certificates \
     cmake \
@@ -20,9 +22,10 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives/* &&\
     wget \
     unzip \
     ros-${ROS_DISTRO}-ros-base \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep update
 
 ARG USERNAME=ros
@@ -31,20 +34,17 @@ ARG USER_GID=$USER_UID
 
 # Create a non-root user
 RUN groupadd --gid $USER_GID $USERNAME \
-  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-  # Add sudo support for the non-root user
-  && apt-get update \
-  && apt-get install -y --no-install-recommends sudo \
-  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-  && chmod 0440 /etc/sudoers.d/$USERNAME \
-  && rm -rf /var/lib/apt/lists/*
-
-# Cyclone DDS
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # Add sudo support for the non-root user
+    && apt-get update \
+    && apt-get install -y --no-install-recommends sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
     && rm -rf /var/lib/apt/lists/*
+
+# Cyclone DDS Config
 COPY cyclonedds.xml /etc/cyclonedds.xml 
-  
+
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \
     echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /home/${USERNAME}/.bashrc && \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -11,12 +11,9 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update || true \
-  && apt-get install -y --no-install-recommends gnupg ca-certificates \
-  && apt-get update \
-  && apt-get upgrade -y
-
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
   locales \
   curl \
   wget \
@@ -92,4 +89,3 @@ ENV SHELL=/bin/bash
 USER ${USERNAME}
 
 CMD ["bash", "-l"]
-

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -14,8 +14,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update || true \
   && apt-get install -y --no-install-recommends gnupg ca-certificates \
   && apt-get update \
-  && apt-get upgrade -y \
-  apt-get install -y --no-install-recommends \
+  && apt-get upgrade -y
+
+RUN apt-get install -y --no-install-recommends \
   locales \
   curl \
   wget \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -42,12 +42,10 @@ RUN add-apt-repository universe \
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-ros-base \
   python3-rosdep \
-  && rm -rf /var/lib/apt/lists/*
-
-# Cyclone DDS
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
   && rm -rf /var/lib/apt/lists/*
+
+# Cyclone DDS Config
 COPY cyclonedds.xml /etc/cyclonedds.xml 
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -11,9 +11,10 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install language
-RUN apt-get update && \
-  apt-get upgrade -y && \
+RUN apt-get update || true \
+  && apt-get install -y --no-install-recommends gnupg ca-certificates \
+  && apt-get update \
+  && apt-get upgrade -y \
   apt-get install -y --no-install-recommends \
   locales \
   curl \
@@ -26,13 +27,11 @@ RUN apt-get update && \
   python3-setuptools \
   software-properties-common \
   tzdata \
-  && locale-gen en_US.UTF-8 \
-  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+  && locale-gen en_GB.UTF-8 \
+  && update-locale LC_ALL=en_GB.UTF-8 LANG=en_GB.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
 
-ENV LANG=en_US.UTF-8
-
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+ENV LANG=en_GB.UTF-8
 
 # Prepare ROS2
 RUN add-apt-repository universe \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -73,6 +73,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \
+  echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /home/${USERNAME}/.bashrc && \
   echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
   echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
   echo "alias t='tmux'" >> /etc/bash.bashrc && \
@@ -89,6 +90,8 @@ ENV VGL_WM=1
 ENV VGL_PROBEGLX=0
 ENV LD_PRELOAD=/usr/lib/libdlfaker.so:/usr/lib/libvglfaker.so
 ENV SHELL=/bin/bash
+
+USER ${USERNAME}
 
 CMD ["bash", "-l"]
 

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-rosdep \
   && rm -rf /var/lib/apt/lists/*
 
-COPY docker/cyclonedds.xml /etc/cyclonedds.xml 
+COPY cyclonedds.xml /etc/cyclonedds.xml 
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update
 

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -39,8 +39,11 @@ RUN add-apt-repository universe \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-ros-base \
+  ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
   python3-rosdep \
   && rm -rf /var/lib/apt/lists/*
+
+COPY ./docker/cyclonedds.xml /etc/cyclonedds.xml 
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update
 
@@ -68,7 +71,9 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
   echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
   echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
   echo "alias t='tmux'" >> /etc/bash.bashrc && \
-  echo "alias cls='clear'" >> /etc/bash.bashrc
+  echo "alias cls='clear'" >> /etc/bash.bashrc && \
+  echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
+  echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
 
 ENV TVNC_VGL=1
 ENV VGL_ISACTIVE=1

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:11.8.0-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:11.8.0-runtime-ubuntu22.04
 ARG ROS_DISTRO=humble
 
 ###########################################

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -72,10 +72,8 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
   echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
   echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
   echo "alias t='tmux'" >> /etc/bash.bashrc && \
-  echo "alias cls='clear'" >> /etc/bash.bashrc && \
-  echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
-  echo "export CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
-
+  echo "alias cls='clear'" >> /etc/bash.bashrc
+  
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV CYCLONEDDS_URI=file:///etc/cyclonedds.xml
 ENV TVNC_VGL=1

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -28,10 +28,8 @@ RUN apt-get update && \
   tzdata \
   && locale-gen en_US.UTF-8 \
   && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean \
-  && rm -rf /var/cache/apt/archives/*
-  
+  && rm -rf /var/lib/apt/lists/*
+
 ENV LANG=en_US.UTF-8
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Cyclone DDS Config
-COPY cyclonedds.xml /etc/cyclonedds.xml 
+COPY cyclonedds.xml /etc/cyclonedds.xml
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update
 
@@ -73,9 +73,11 @@ RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root
   echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
   echo "alias t='tmux'" >> /etc/bash.bashrc && \
   echo "alias cls='clear'" >> /etc/bash.bashrc && \
-  echo "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
-  echo "CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
+  echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /etc/bash.bashrc && \
+  echo "export CYCLONEDDS_URI=file:///etc/cyclonedds.xml" >> /etc/bash.bashrc
 
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ENV CYCLONEDDS_URI=file:///etc/cyclonedds.xml
 ENV TVNC_VGL=1
 ENV VGL_ISACTIVE=1
 ENV VGL_FPS=25

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-rosdep \
   && rm -rf /var/lib/apt/lists/*
 
-COPY ./docker/cyclonedds.xml /etc/cyclonedds.xml 
+COPY docker/cyclonedds.xml /etc/cyclonedds.xml 
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update
 

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -12,7 +12,8 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install language
-RUN apt-get update ; \
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
+  apt-get update ; \
   apt-get upgrade -y && \
   apt-get install -y --no-install-recommends \
   locales \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -28,11 +28,11 @@ RUN apt-get install -y --no-install-recommends \
   python3-setuptools \
   software-properties-common \
   tzdata \
-  && locale-gen en_GB.UTF-8 \
-  && update-locale LC_ALL=en_GB.UTF-8 LANG=en_GB.UTF-8 \
+  && locale-gen en_US.UTF-8 \
+  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
 
-ENV LANG=en_GB.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Prepare ROS2
 RUN add-apt-repository universe \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -18,6 +18,7 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
   apt-get install -y --no-install-recommends \
   locales \
   curl \
+  wget \
   ca-certificates \
   gnupg2 \
   lsb-release \
@@ -25,7 +26,6 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
   nano \
   python3-setuptools \
   software-properties-common \
-  wget \
   tzdata \
   && locale-gen en_US.UTF-8 \
   && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:11.8.0-runtime-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:11.8.0-devel-ubuntu22.04
 ARG ROS_DISTRO=humble
 
 ###########################################

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update ; \
   apt-get install -y --no-install-recommends \
   locales \
   curl \
+  ca-certificates \
   gnupg2 \
   lsb-release \
   git \
@@ -39,10 +40,13 @@ RUN add-apt-repository universe \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-ros-base \
-  ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
   python3-rosdep \
   && rm -rf /var/lib/apt/lists/*
 
+# Cyclone DDS
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+  ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+  && rm -rf /var/lib/apt/lists/*
 COPY cyclonedds.xml /etc/cyclonedds.xml 
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && rosdep init && rosdep update

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -69,6 +69,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Configure bash profile
 RUN echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /root/.bashrc && \
   echo "if [ -f /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi" >> /home/${USERNAME}/.bashrc && \
+  chown ${USERNAME}:${USERNAME} /home/${USERNAME}/.bashrc && \
   echo 'PS1="${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/bash.bashrc && \
   echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc && \
   echo "alias t='tmux'" >> /etc/bash.bashrc && \

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -12,8 +12,7 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install language
-RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
-  apt-get update ; \
+RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y --no-install-recommends \
   locales \
@@ -29,7 +28,10 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives/* && \
   tzdata \
   && locale-gen en_US.UTF-8 \
   && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/*
+  
 ENV LANG=en_US.UTF-8
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/cuda_desktop.dockerfile
+++ b/cuda_desktop.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=lcas.lincoln.ac.uk/ros_cuda:humble-main
 
 ###########################################
 FROM ${BASE_IMAGE} AS base

--- a/cuda_desktop.dockerfile
+++ b/cuda_desktop.dockerfile
@@ -3,6 +3,6 @@ ARG BASE_IMAGE
 ###########################################
 FROM ${BASE_IMAGE} AS base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-desktop \
     && rm -rf /var/lib/apt/lists/*

--- a/cuda_desktop.dockerfile
+++ b/cuda_desktop.dockerfile
@@ -5,4 +5,4 @@ FROM ${BASE_IMAGE} AS base
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-desktop \
-    && rm -rf /var/lib/apt/lists/*
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/docker/cyclonedds.xml
+++ b/docker/cyclonedds.xml
@@ -1,0 +1,10 @@
+<CycloneDDS>
+  <Domain>
+    <General>
+      <AllowMulticast>true</AllowMulticast>
+    </General>
+    <Discovery>
+      <ParticipantIndex>auto</ParticipantIndex>
+    </Discovery>
+  </Domain>
+</CycloneDDS>


### PR DESCRIPTION
This is a PR to add Cyclone DDS as the main ROS middleware and focus on adding that and making it work well. The following text below is a Copilot generated summary of the changes, that have been reviewed for accuracy.

This was developed during some downtime on the self-hosted LCAS runners which led to some troubleshooting which have implemented extra changes which should improve the containers as a whole.

---

This pull request introduces several improvements to the Docker build workflow and base images for ROS2 with CUDA support. The main focus is on adding Cyclone DDS configuration, updating the CUDA base image, and enhancing the Dockerfiles for better reproducibility and ROS2 middleware support.

**Enhancements to ROS2 and CUDA Docker images:**

* Cyclone DDS integration:
  * Added installation of `ros-${ROS_DISTRO}-rmw-cyclonedds-cpp` in both `base.dockerfile` and `cuda.dockerfile`, along with copying the new `cyclonedds.xml` configuration file and setting relevant environment variables (`RMW_IMPLEMENTATION`, `CYCLONEDDS_URI`). [[1]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[2]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2R42-R47) [[3]](diffhunk://#diff-db889959cd32d5f26a6d3f2a615109e866e93de90ab8961853c484adafea4845R1-R10) [[4]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[5]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2R71-R79)
  * Created a default Cyclone DDS configuration file at `docker/cyclonedds.xml` to enable multicast and auto participant indexing.

* Docker image build workflow updates:
  * Updated the CUDA base image in the workflow to `nvidia/cuda:12.9.1-runtime-ubuntu24.04` for improved compatibility and performance.
  * Added a step to pull the base image before building, ensuring the latest image is used.

**General improvements and fixes:**

* Enhanced package installation:
  * Added missing packages (`ca-certificates`, `gnupg`, `wget`) and switched to `--no-install-recommends` for leaner images in both `base.dockerfile` and `cuda.dockerfile`. [[1]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[2]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2L14-R32)
  * Improved locale setup and ensured `LANG` is set to `en_US.UTF-8`. [[1]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[2]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2L14-R32)

* User and bash profile configuration:
  * Added sudo support for the non-root user and ensured bash profile is correctly configured and owned by the user. [[1]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[2]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2R71-R79)
  * Changed Dockerfile to run as the non-root user by default. [[1]](diffhunk://#diff-ad540a700b3b93e9b91ec1d2b60fda68a8aafaa708e0674da829932cbc75e78fL13-R61) [[2]](diffhunk://#diff-09301be36419ca2a79b2ed9b3ef2943a609b4704f5819b54acb705e6a07f69a2L83-R92)

* Desktop image improvements:
  * Set a default base image for `cuda_desktop.dockerfile` and switched to using `sudo` for package installation.

These changes collectively improve the robustness, security, and ROS2 middleware support of the Docker images and workflows.