### PR TITLE
ROS 2 Lyrical Luth

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -80,6 +80,14 @@ jobs:
             dockerfile: "base.dockerfile"
             architectures: "linux/amd64,linux/arm64"
 
+          # ROS Lyrical
+          - base_image: "ros:lyrical"
+            push_image: "ros"
+            ros_distro: "lyrical"
+            tag_stem: "lyrical"
+            dockerfile: "base.dockerfile"
+            architectures: "linux/amd64,linux/arm64"
+
           # ROS CUDA 11.8 Humble
           - base_image: "nvidia/cuda:11.8.0-runtime-ubuntu22.04"
             push_image: "ros_cuda"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository manages the following containers:
 
 | Image | Tags | Includes | Choose This If... | Dockerfile |
 | --- | --- | --- | --- | --- |
-| `lcas.lincoln.ac.uk/ros` | `humble`, `jazzy` | Minimal ROS runtime and tooling, plus VirtualGL | You need ROS with graphical workflows (including VirtualGL-based rendering) but do not need NVIDIA CUDA | [base.dockerfile](base.dockerfile) |
+| `lcas.lincoln.ac.uk/ros` | `humble`, `jazzy`, `lyrical` | Minimal ROS runtime and tooling, plus VirtualGL | You need ROS with graphical workflows (including VirtualGL-based rendering) but do not need NVIDIA CUDA | [base.dockerfile](base.dockerfile) |
 | `lcas.lincoln.ac.uk/ros_cuda` | `humble-11.8`, `humble-12.8`, `jazzy-12.9` | ROS plus NVIDIA CUDA support | You need CUDA-enabled GPU acceleration for simulation or AI workloads | [cuda.dockerfile](cuda.dockerfile) |
 | `lcas.lincoln.ac.uk/ros_cuda_desktop` | `humble-11.8`, `humble-12.8`, `jazzy-12.9` | ROS + CUDA + `ros-{distro}-desktop` package set | You need CUDA and the full ROS desktop stack | [desktop.dockerfile](desktop.dockerfile) |
 | `lcas.lincoln.ac.uk/vnc` | `latest` | Browser-accessible VNC/X11 display endpoint | You need a shared web-based display target for GUI applications from other containers | [vnc.dockerfile](vnc.dockerfile) |


### PR DESCRIPTION
Resolves #15 by adding a Lyrical Luth container variant. 

⚠️ Blocked until CUDA base is released based on Ubuntu 26.04
⚠️ Blocked until apt repo's change from `ros2-testing` to `lyrical`... likely date is Friday 22nd May 2026